### PR TITLE
dialer: fix fc on secundary users

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -59,6 +59,9 @@
     <uses-permission android:name="android.permission.STOP_APP_SWITCHES" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="com.qualcomm.permission.USE_PHONE_SERVICE" />
+    <!-- Required to cancel notifications from non-primary users through
+         TelecommManager which is a singleton service -->
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS" />
 
     <application
         android:name="DialerApplication"


### PR DESCRIPTION
Caused by calling TelecommManager which is a singleton service which impersonate
the user to remove missed call notifications.

Change-Id: I584ef7f31aafe0aa3a6f3ab24434ed0544cbb598
JIRA: CYAN-7151
Signed-off-by: Jorge Ruesga jorge@ruesga.com
